### PR TITLE
Fix retry counter on failed requests

### DIFF
--- a/loxone.smart.gateway/Api/PhilipsHue/PhilipsHueMessageSender.cs
+++ b/loxone.smart.gateway/Api/PhilipsHue/PhilipsHueMessageSender.cs
@@ -57,14 +57,17 @@ public class PhilipsHueMessageSender
                     try
                     {
                         var result = await ProcessMessage(model);
-                        
+
                         if (!result)
+                        {
+                            model.Retries++;
                             _requestModels.Enqueue(model);
+                        }
                     }
                     catch (Exception ex)
                     {
                         model.Retries++;
-                    
+
                         Log.Error(ex, "Error while processing message");
                         _requestModels.Enqueue(model);
                     }


### PR DESCRIPTION
## Summary
- increment retry counter when hue message processing fails

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684122bcede0832cbc3f22f5cb290303